### PR TITLE
Removed WikiChatter and Wikitools from requirements.txt

### DIFF
--- a/wikum/requirements.txt
+++ b/wikum/requirements.txt
@@ -1,7 +1,6 @@
 Django==1.9.1
 MySQL-python==1.2.5
 SQLAlchemy==1.1.3
-WikiChatter==0.2.3
 amqp==2.1.1
 billiard==3.5.0.1
 boto==2.39.0
@@ -48,7 +47,6 @@ traitlets==4.1.0
 update-checker==0.11
 vine==1.1.3
 wheel==0.24.0
-wikitools==1.4
 wsgiref==0.1.2
 numpy==1.10.4
 scikit-learn==0.17.1


### PR DESCRIPTION
Removed WikiChatter and Wikitools from requirements.txt since these two are now replaced by other files.