### PR TITLE
'parse'

### DIFF
--- a/wikum/website/import_data.py
+++ b/wikum/website/import_data.py
@@ -49,7 +49,7 @@ def get_article(url, source, num):
             from wikitools import wiki, api
             site = wiki.Wiki(domain + '/w/api.php')
             page = urllib2.unquote(str(wiki_sub[0]) + ':' + str(wiki_page))
-            params = {'action': 'parse', 'prop': 'sections','page': page }
+            params = {'action': 'parse', 'prop': 'sections','page': page ,'redirects':'yes' }
             request = api.APIRequest(site, params)
             result = request.query()
 
@@ -86,7 +86,7 @@ def get_wiki_talk_posts(article, current_task, total_count):
     
     title = article.title.split(' - ')
     
-    params = {'action': 'query', 'titles': title[0],'prop': 'revisions', 'rvprop': 'content', 'format': 'json'}
+    params = {'action': 'query', 'titles': title[0],'prop': 'revisions', 'rvprop': 'content', 'format': 'json','redirects':'yes'}
     request = api.APIRequest(site, params)
     result = request.query()
     id = article.disqus_id.split('#')[0]

--- a/wikum/website/import_data.py
+++ b/wikum/website/import_data.py
@@ -43,7 +43,7 @@ def get_article(url, source, num):
             wiki_parts = ':'.join(wiki_sub[1:]).split('#')
             wiki_page = wiki_parts[0]
             section = None
-            if len(url_parts) > 1:
+            if len(wiki_parts) > 1:
                 section = wiki_parts[1]
             
             from wikitools import wiki, api

--- a/wikum/website/import_data.py
+++ b/wikum/website/import_data.py
@@ -48,7 +48,8 @@ def get_article(url, source, num):
             
             from wikitools import wiki, api
             site = wiki.Wiki(domain + '/w/api.php')
-            params = {'action': 'parse', 'prop': 'sections','page': str(wiki_sub[0]) + ':' + str(wiki_page)}
+            page = urllib2.unquote(str(wiki_sub[0]) + ':' + str(wiki_page))
+            params = {'action': 'parse', 'prop': 'sections','page': page }
             request = api.APIRequest(site, params)
             result = request.query()
 
@@ -201,7 +202,7 @@ def import_wiki_talk_posts(comments, article, reply_to, current_task, total_coun
             if comment.get('time_stamp'):
                 time = datetime.datetime.strptime(comment['time_stamp'], '%H:%M, %d %B %Y (%Z)')
 
-            cosigners = comment['cosigners']
+            cosigners = [sign['author'] for sign in comment['cosigners']]
             comment_cosigners = import_wiki_authors(cosigners, article)
 
             comment_wikum = Comment.objects.create(article = article,

--- a/wikum/website/static/website/js/summary.js
+++ b/wikum/website/static/website/js/summary.js
@@ -43,7 +43,7 @@ function display_comments(discuss_info_list, level, total_summary_text, auto_hid
 $(document).ready(function () {
 	
 	var article_url = getParameterByName('article');
-	article_url = article_url.replace('#','%23');
+	article_url = article_url = article_url.replace('#','%23').replace('&', '%26');
 	var next = parseInt(getParameterByName('next'));
 	if (!next) {
 		next = 0;


### PR DESCRIPTION
1.Enabled Wikipedia pages(not just sections) that exist as RfCs to be parsed
2.Replaced '%xx' escapes in order to parse all urls
3.Fixed code to properly grab 'cosigners' of a comment
4.Enabled parsing Wikipedia urls that need redirecting