### PR TITLE
Grab section

### DIFF
--- a/wikum/website/import_data.py
+++ b/wikum/website/import_data.py
@@ -63,7 +63,7 @@ def get_article(url, source, num):
             title = result['parse']['title']
             if section_title:
                 title = title + ' - ' + section_title
-            link = url
+            link = urllib2.unquote(url)
         article,_ = Article.objects.get_or_create(disqus_id=id, title=title, url=link, source=source)
     else:
         article = article[num]

--- a/wikum/website/models.py
+++ b/wikum/website/models.py
@@ -42,6 +42,11 @@ class Article(models.Model):
     comment_num = models.IntegerField(default=0)
     summary_num = models.IntegerField(default=0)
 
+    #"section_index" is a column for storing the index number of the section within the page.
+    #There are some cases when wikicode does not parse a section as a section when given a whole page.
+    #To prevent this, we first grab only the section(not the entire page) using "section_index" and parse it.
+    section_index = models.IntegerField(default=0)
+
     def __unicode__(self):
         return self.title
     

--- a/wikum/website/static/website/js/summary.js
+++ b/wikum/website/static/website/js/summary.js
@@ -2,7 +2,6 @@
 
 
 function display_comments(discuss_info_list, level, total_summary_text, auto_hide) {
-	
 	for (var i=0; i< discuss_info_list.length; i++) {
 		info = discuss_info_list[i];
 		
@@ -43,7 +42,8 @@ function display_comments(discuss_info_list, level, total_summary_text, auto_hid
 $(document).ready(function () {
 	
 	var article_url = getParameterByName('article');
-	article_url = article_url = article_url.replace('#','%23').replace('&', '%26');
+	article_url = encodeURI(article_url).replace(/%5B/g, '[').replace(/%5D/g, ']');
+	article_url = article_url.replace('#','%23').replace('&', '%26')
 	var next = parseInt(getParameterByName('next'));
 	if (!next) {
 		next = 0;
@@ -69,9 +69,7 @@ $(document).ready(function () {
 	    success: function (data) { 
 	    	
 	    	unpack_posts(data.posts.children);
-
 			summary_text = display_comments(data.posts.children, 0, '');
-			
         	$('#summary').html(summary_text);
         	
         	if (data.posts.children.length < 5) {

--- a/wikum/website/static/website/js/summary_base.js
+++ b/wikum/website/static/website/js/summary_base.js
@@ -247,12 +247,13 @@ function split_text(text, summary_text, d_id) {
 			summary_text += '<div id="hidden_' + d_id + '" class="hidden_node" style="display: none; margin-top: 15px;"><P>';
 			hidden = true;
 		} else {
+
 			var pattern = /\[quote\]/g;
 			part = part.replace(pattern, '<blockquote>');
 			var pattern = /\[endquote\]/g;
 			part = part.replace(pattern, '</blockquote>');
-			
-			if (part.indexOf('[[') > -1) {
+
+			if (part.indexOf('[[') > -1 && part.indexOf(']]') > -1) {
 				var comment = part.match(/\[\[(.*)\]\]/);
 				var link = comment[1];
 				part = part.replace(/\[\[(.*)\]\]/g, "");
@@ -404,7 +405,7 @@ function display_comment(info, d_id) {
 		text += '\n<BR><a>...</a><BR>\n';
 		text += extra_text;
 	}
-	
+
 	summary_text = split_text(text, summary_text, d_id);
 
 	summary_text += '</P>';

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -16,7 +16,7 @@ from math import floor
 from django.views.decorators.csrf import csrf_exempt
 from website.import_data import get_source, get_article
 
-import urllib
+import urllib2
 
 from wikimarkup import parse
 import parse_helper
@@ -153,7 +153,7 @@ def summary4(request):
     return summary_page(request)
     
 def summary_data(request):
-    url = request.GET['article']
+    url = urllib2.unquote(request.GET['article'])
     num = int(request.GET.get('num', 0))
     sort = request.GET.get('sort', 'id')
     

--- a/wikum/wikichatter/section.py
+++ b/wikum/wikichatter/section.py
@@ -24,12 +24,13 @@ class Section(object):
     def _load_section_info(self):
         wiki_headings = [h for h in self._wikicode.filter_headings()]
 
-        if len(wiki_headings) > 1:
-            raise TooManyHeadingsError(wiki_headings)
         if len(wiki_headings) == 0:
             self.heading = None
             self.level = EPI_LEVEL
         else:
+            # Before TooManyHeadingsError was raised when there were more than 1 heading,
+            # however in Wikum's case it's okay because the code in 'import_data.py'
+            # makes sure the right section is being parsed.
             self.heading = str(wiki_headings[0].title)
             self.level = wiki_headings[0].level
         self.text = self._get_section_text_from_wikicode(self._wikicode)

--- a/wikum/wikichatter/signatureutils.py
+++ b/wikum/wikichatter/signatureutils.py
@@ -188,7 +188,8 @@ def _extract_rightmost_user(wcode):
     func_picker.extend([(l[0], l[1], _extract_usercontribs_user) for l in uc_locs])
 
     if len(func_picker) == 0:
-        raise NoUsernameError(text)
+        #able to return None because Wikum's code handles it in import_data.py
+        return None
     (start, end, extractor) = max(func_picker, key=lambda e: e[1])
     user = extractor(text[start:end])
     return user


### PR DESCRIPTION
1. Enabled encoding and decoding urls properly when storing article in DB and then retrieving it to show it.  Character '&' needed to be changed to '%26' but it couldn't be using 'encodeURI' so manually replaced it.  Encoding and decoding urls is crucial in order to go to the summary page without any error.

2. Fixed problem of grabbing the right section. Previously Wikum ingested all comments within a page when a section cannot be found due to wikicode's parsing. This is because wikicode sometimes interpret sections as not "sections" but subparts of another section in cases when parsing a whole page. To prevent this, grab the section first and parse that section only, by using "rvsection" in mediawiki query.
**Important!!! The table 'website_article' needs a column 'section_index' for this.**

3. Removed the error thrown when multiple headings exist in a section from section.py in wikichatter. It's okay in Wikum because import_data.py makes sure only the right section is parsed, and it seems it's inevitable in some RfCs to include multiple headings.

4. Previously wikichatter threw an error "NoUsernameError" when a user name is not found, including the case of cosigners. Changed this to returning 'None', since Wikum's code can handle it in case of 'author' (TODO: code needs to be written in case of cosigners.) 
 
5. Handled a certain exception of time format, of which 'Jul' was written instead of 'July'. (TODO: Need to write a general regex for handling other time related exceptions in import_data.py)

6. Handled exception of a broken link(only '[[' was included in text (without any ']]' following after) even though it did not lead to a link).  Previously in summary_base.js it was only tested whether '[[' was included, but this allows a text blob '[[blah' to be misinterpreted as a link. Currently saw only one case like this, but fixed it. 

7. Added a helper function for removing <div...>...</div> from text before parsing, in order to prevent some RfC sections being ingested as just one blob of comment. For example, "<div class="boilerplate" style="background-color: ........>....</div>" that surrounds the whole comments prevents a RfC from being parsed properly
 
8.  Although this is not code related, the column 'url' in table "website_article" needs to allow more characters. There was a really long url that couldn't be stored properly because of the length constraint. 