### PR TITLE
Removed throwing error when no user name is found.

### DIFF
--- a/wikum/website/import_data.py
+++ b/wikum/website/import_data.py
@@ -151,7 +151,14 @@ def import_wiki_sessions(sections, article, reply_to, current_task, total_count)
     return total_count
     
 def import_wiki_authors(authors, article):
-    authors_list = '|'.join(authors)
+    found_authors = []
+    anonymous_exist = False
+    for author in authors:
+        if author:
+            found_authors.append(author)
+        else:
+            anonymous_exist = True
+    authors_list = '|'.join(found_authors)
     
     from wikitools import wiki, api
     domain = article.url.split('/wiki/')[0]
@@ -180,7 +187,10 @@ def import_wiki_authors(authors, article):
         except Exception:
             comment_author = CommentAuthor.objects.create(username=user['name'], is_wikipedia=True)
         comment_authors.append(comment_author)
-        
+
+    if anonymous_exist:
+        comment_authors.append(CommentAuthor.objects.get(disqus_id='anonymous', is_wikipedia=True))
+
     return comment_authors
     
     

--- a/wikum/wikichatter/signatureutils.py
+++ b/wikum/wikichatter/signatureutils.py
@@ -1,7 +1,7 @@
 import re
 import mwparserfromhell as mwp
 from .error import Error
-
+import logging
 
 class SignatureUtilsError(Error):
     pass
@@ -188,8 +188,13 @@ def _extract_rightmost_user(wcode):
     func_picker.extend([(l[0], l[1], _extract_usercontribs_user) for l in uc_locs])
 
     if len(func_picker) == 0:
-        # able to return None because Wikum's code handles it in import_data.py
-        # raise NoUsernameError(text)
+        # Able to return None because Wikum's code handles it in import_data.py
+        # Throwing error prevents whole parsing, therefore print log statement instead.
+        logging.basicConfig(level=logging.INFO,
+                           format='[ %(asctime)s %(levelname)-8s ]\n%(message)s',
+                           datefmt='%a, %d %b %Y %H:%M:%S')
+        logging.warning("Did not find user name in comment. This could be due to problem in parsing."
+                        "\n============== Comment with no user name ==============\n" + text)
         return None
     (start, end, extractor) = max(func_picker, key=lambda e: e[1])
     user = extractor(text[start:end])

--- a/wikum/wikichatter/signatureutils.py
+++ b/wikum/wikichatter/signatureutils.py
@@ -188,7 +188,9 @@ def _extract_rightmost_user(wcode):
     func_picker.extend([(l[0], l[1], _extract_usercontribs_user) for l in uc_locs])
 
     if len(func_picker) == 0:
-        raise NoUsernameError(text)
+        # able to return None because Wikum's code handles it in import_data.py
+        # raise NoUsernameError(text)
+        return None
     (start, end, extractor) = max(func_picker, key=lambda e: e[1])
     user = extractor(text[start:end])
     return user


### PR DESCRIPTION
The error thrown in this case prevents complete ingestion of comments.
Returning None is okay because code in import_data.py handles it.
**However, this error gives helpful feedback when parsing isn't done correctly. So it might be better to leave it as it is. 
I removed it because the error stops the ingestion of comments. 
When removed, the comments will all be ingested, but some comments could be blobbed together, due to wrong parsing.**