### PR TITLE
Summary replies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 requirements.txt
 private.py
 wikum/env/
-wikum/private_config.py
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 requirements.txt
 private.py
 wikum/env/
-
+wikum/private_config.py

--- a/wikum/private_config.py
+++ b/wikum/private_config.py
@@ -1,11 +1,11 @@
 MYSQL_PROD = {
         'NAME' : 'wikum',
-        'USER' : 'stian8',
-        'PASSWORD' : 'password8',
+        'USER' : 'myUSer',
+        'PASSWORD' : 'myPassword',
         'HOST' : 'localhost',  
     }
 
-SECRET_KEY = 'qwpeh2389hofnqeugv832'
+SECRET_KEY = ''
 DISQUS_API_KEY = ''
 PRAW_CLIENT_SECRET = ''
 PRAW_CLIENT_ID = ''

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -752,14 +752,20 @@ a.btn-edit {
 	resize: vertical;
 }
 
+#evaluate_summary_modal_box{
+	width: 70%;
+	height: 80%;
+}
+
 #evaluate_summary_box {
-	height: 140px;
+	height: 350px;
     overflow-y: scroll;
     border: 1px #000000 solid;
     display: block;
     padding-left: 8px;
     padding-right: 8px;
     padding-top: 5px;
+    resize: vertical;
 }
 
 #summarize_multiple_comment_box {

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -105,6 +105,25 @@ a:hover {
     font-size: 11px;
 }
 
+#new_node {
+	position: absolute;
+	top: 120px;
+	left: 70px;
+}
+#create_new{
+	width: 20px;
+	height: 20px;
+	text-align: center;
+	padding: 1px 0;
+	font-size: 12px;
+	font-weight: bold;
+	line-height: 1.4;
+	border-radius: 15px;
+}
+#new_comment:hover{
+	cursor: pointer;
+}
+
 path.link {
     fill: none;
     stroke: #ccc;

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -348,11 +348,11 @@ rect.selection {
 	color: gray;
 }
 
-#unsummarized_children {
+#summarized_children {
 	margin-top: 15px;
 }
 
-#unsummarized_id_list {
+#summarized_id_list {
     max-height: 100px;
     overflow-y: scroll;
     border: 1px gray solid;

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -348,6 +348,17 @@ rect.selection {
 	color: gray;
 }
 
+#unsummarized_children {
+	margin-top: 15px;
+}
+
+#unsummarized_id_list {
+	height: 100px;
+    max-height: 100px;
+    overflow-y: scroll;
+    border: 1px gray solid;
+}
+
 .comment_box,
 .reply_comment_comment {
 	position: relative;
@@ -438,7 +449,7 @@ rect.selection {
 		--background: hsl(30, 100%, 86%);
 	}
 
-.summarized.collapsed {
+.unsummarized.collapsed {
 	background-color: hsl(195, 59%, 96%);
     margin-bottom: 10px;
     padding: 1.2em;
@@ -447,7 +458,7 @@ rect.selection {
     --link-color: hsl(195, 59%, 60%);
 }
 
-	.summarized.collapsed.comment_box footer {
+	.unsummarized.collapsed.comment_box footer {
 		padding: 0;
 		margin: -.2em -1.2em;
 		background: var(--background);
@@ -455,7 +466,7 @@ rect.selection {
 		white-space: normal;
 	}
 
-		.summarized.collapsed.comment_box footer a {
+		.unsummarized.collapsed.comment_box footer a {
 			padding: .5em;
 			color: var(--link-color);
 			font-weight: 500;
@@ -463,7 +474,7 @@ rect.selection {
 			display: inline-block;
 		}
 
-		.summarized.collapsed.comment_box footer a:hover {
+		.unsummarized.collapsed.comment_box footer a:hover {
 			color: hsla(0,0%,100%,.9);
 			background: var(--link-color);
 		}
@@ -526,6 +537,10 @@ rect.selection {
 
 .highlighted.summary{
 	border: 1.8px #000000 solid;
+}
+
+.highlighted.unsummarized.collapsed{
+	border: 1px #000000 solid;
 }
 
 .highlighted {
@@ -682,6 +697,10 @@ textarea {
 .input-sm {
     height: 25px;
     line-height: 1.2;
+}
+
+input[type=checkbox] {
+    margin: 5px;
 }
 
 #count_result {

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -120,8 +120,15 @@ a:hover {
 	line-height: 1.4;
 	border-radius: 15px;
 }
+
 #new_comment:hover{
 	cursor: pointer;
+}
+
+#new_node_textarea {
+	height: 100px;
+	max-height: 100px;
+    overflow-y: scroll;
 }
 
 path.link {

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -429,6 +429,35 @@ rect.selection {
 		--background: hsl(30, 100%, 86%);
 	}
 
+.summarized.collapsed {
+	background-color: hsl(195, 59%, 96%);
+    margin-bottom: 10px;
+    padding: 1.2em;
+    padding-bottom: .2em;
+    border: 1px hsl(195, 59%, 85%) solid;
+    --link-color: hsl(195, 59%, 60%);
+}
+
+	.summarized.collapsed.comment_box footer {
+		padding: 0;
+		margin: -.2em -1.2em;
+		background: var(--background);
+		--background: hsl(195, 59%, 90%);
+		white-space: normal;
+	}
+
+		.summarized.collapsed.comment_box footer a {
+			padding: .5em;
+			color: var(--link-color);
+			font-weight: 500;
+			font-size: 13px;
+			display: inline-block;
+		}
+
+		.summarized.collapsed.comment_box footer a:hover {
+			color: hsla(0,0%,100%,.9);
+			background: var(--link-color);
+		}
 
 .collapsed {
 	background-color: hsl(50, 100%, 95%);

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -341,8 +341,16 @@ rect.selection {
     fill            : transparent;
 }
 
+.id_val {
+	position: absolute;
+	top: 2px;
+	left: 8px;
+	color: gray;
+}
+
 .comment_box,
 .reply_comment_comment {
+	position: relative;
     background-color: hsl(195, 59%, 96%);
     margin-bottom: 10px;
     padding: 1.2em;
@@ -359,6 +367,7 @@ rect.selection {
 
 .comment_box,
 .summarize_comment_comment {
+	position: relative;
 	background-color: hsl(195, 59%, 96%);
 	margin-bottom: 10px;
 	padding: 1.2em;

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -353,7 +353,6 @@ rect.selection {
 }
 
 #unsummarized_id_list {
-	height: 100px;
     max-height: 100px;
     overflow-y: scroll;
     border: 1px gray solid;
@@ -685,6 +684,9 @@ textarea {
 	cursor: pointer;
 }
 
+select {
+	margin: 5px;
+}
 
 #button_subtree {
     position: absolute;
@@ -701,6 +703,14 @@ textarea {
 
 input[type=checkbox] {
     margin: 5px;
+}
+
+#unsummarized_textbox {
+	width:50px;
+}
+
+#mark_unsummarized {
+	margin: 5px;
 }
 
 #count_result {

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -295,12 +295,17 @@ $('#reply_modal_box').on('show.bs.modal', function(e) {
 			}
 	});
 
+	var class_sum = "";
 	if (d.replace_node) {
-		//TODO(stian8): replies/commenting not yet implemented for summaries
+		var node_text = '<strong>Summary Node:</strong><BR>' + render_summary_node(d, false);
+		var class_sum = "summary_box";
+	} else if (d.summary != '') {
+		var node_text = '<strong>Summary:</strong> ' + render_summary_node(d, false);
 	} else {
-		var text = '<div class="reply_comment_comment reply_comment">' + d.name + '</div>';
-		$('#reply_comment_text').text('Reply to this comment.');
+		var node_text = d.name;
 	}
+	
+	var text = '<div class="reply_comment_comment' + ' ' + class_sum + '">' + node_text+ '</div>';
 
 	$('#reply_comment_box').html(text);
 
@@ -1727,6 +1732,7 @@ $('#summarize_multiple_modal_box').on('show.bs.modal', function(e) {
 					
 					if ($('#access_mode').attr('data-access') == "1") {
 						text += `<footer>
+							<a data-toggle="modal" data-backdrop="false" data-did="${new_d.id}" data-target="#reply_modal_box" data-id="${new_d.id}">Reply</a>
 							<a data-toggle="modal" data-backdrop="false" data-did="${new_d.id}" data-target="#summarize_multiple_modal_box" data-type="edit_summarize" data-id="${new_d.id}">Edit Summary</a>
 							<a data-toggle="modal" data-backdrop="false" data-target="#confirm_delete_modal_box" data-id="${new_d.id}">Delete Summary</a>
 							<a data-toggle="modal" data-backdrop="false" data-did="${new_d.d_id}" data-target="#evaluate_summary_modal_box" data-type="evaluate_summary" data-id="${new_d.id}">Evaluate Summary</a>
@@ -1847,12 +1853,12 @@ $('#summarize_multiple_modal_box').on('show.bs.modal', function(e) {
 					
 					if ($('#access_mode').attr('data-access') == "1") {
 						text += `<footer>
+							<a data-toggle="modal" data-backdrop="false" data-did="${d.id}" data-target="#reply_modal_box" data-id="${d.id}">Reply</a>
 							<a data-toggle="modal" data-backdrop="false" data-did="${d.id}" data-target="#summarize_multiple_modal_box" data-type="edit_summarize" data-id="${d.id}">Edit Summary Node</a>
 							<a data-toggle="modal" data-backdrop="false" data-target="#confirm_delete_modal_box" data-id="${d.id}">Delete Summary</a>
 							<a data-toggle="modal" data-backdrop="false" data-did="${d.d_id}" data-target="#evaluate_summary_modal_box" data-type="evaluate_summary" data-id="${d.id}">Evaluate Summary</a>
 						</footer>`;
 					}
-					// TODO(stian8): add options for commenting: Reply
 
 					$('#comment_' + d.id).html(text);
 
@@ -3704,10 +3710,10 @@ function construct_comment(d) {
 			}
 			text += '<div id="orig_' + d.id + '" style="display: none;" class="original_comment">' + d.name + '</div>';
 		} else {
-			// TODO(stian8): comment access only
 			if ($('#access_mode').attr('data-access') == "1") {
 				// thread summary
 				text += `<footer>
+					<a data-toggle="modal" data-backdrop="false" data-did="${d.d_id}" data-target="#reply_modal_box" data-id="${d.id}">Reply</a>
 					<a data-toggle="modal" data-backdrop="false" data-did="${d.d_id}" data-target="#summarize_multiple_modal_box" data-type="edit_summarize" data-id="${d.id}">Edit Summary</a>
 					<a data-toggle="modal" data-backdrop="false" data-target="#confirm_delete_modal_box" data-id="${d.id}">Delete Summary</a>
 					<a data-toggle="modal" data-backdrop="false" data-did="${d.d_id}" data-target="#tag_modal_box" data-type="tag_one" data-id="${d.id}">Tag Summary</a>

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -1693,6 +1693,8 @@ $('#summarize_multiple_modal_box').on('show.bs.modal', function(e) {
 						 new_d.extrasumwiki = res.bottom_summary_wiki;
 					}
 
+					mark_children_summarized(new_d);
+
 					for (var d=0; d<children.length; d++) {
 						for (var i=0; i<children[d].parent.children.length; i++) {
 							if (children[d].parent.children[i] == children[d]) {
@@ -1796,6 +1798,8 @@ $('#summarize_multiple_modal_box').on('show.bs.modal', function(e) {
 							 new_d.sumwiki = res.top_summary_wiki;
 							 new_d.extrasumwiki = res.bottom_summary_wiki;
 						}
+
+						mark_children_summarized(new_d);
 
 						for (var i=0; i<d.parent.children.length; i++) {
 							if (d.parent.children[i] == d) {
@@ -2072,6 +2076,7 @@ function cascade_undo_collapses(d) {
 	console.log(d.id);
 	console.log('collapse false');
 	d.collapsed = false;
+	d.summarized = false;
 
 	if (!d.replace_node) {
 		d3.select("#node_" + d.id)
@@ -2096,6 +2101,7 @@ function cascade_collapses(d) {
 	console.log(d.id);
 	console.log('collapse true');
 	d.collapsed = true;
+	d.summarized = true;
 
 	if (!d.replace_node) {
 		d3.select("#node_" + d.id)
@@ -2598,8 +2604,10 @@ function cite_comment(did) {
 function delete_children_boxes(node) {
 	if (node.children) {
 		for (var i=0; i<node.children.length; i++) {
-			$('#comment_' + node.children[i].id).remove();
-			delete_children_boxes(node.children[i]);
+			if (!node.summarized == false) {
+				$('#comment_' + node.children[i].id).remove();
+				delete_children_boxes(node.children[i]);
+			}
 		}
 	}
 }
@@ -2997,6 +3005,7 @@ function dragmove(d) {
         	});
         }
 };
+
 
 function expand(d) {
 	if (d.replace_node) {
@@ -3795,7 +3804,6 @@ function clear_box_top() {
 
 
 function get_subtree_box(text, d, level) {
-
 	if (d.children) {
 		for (var i=0; i<d.children.length; i++) {
 			var levelClass = level > 2? "level3" : `level${level}`;
@@ -4254,7 +4262,6 @@ function showdiv(d) {
 	}
 }
 
-
 function hide_replace_nodes(id) {
 	d = nodes_all[id-1];
 
@@ -4280,6 +4287,37 @@ function hide_replace_nodes(id) {
 		$('#expand').html("");
 	}
 }
+// function hide_replace_nodes(id) {
+// 	console.log("collapse summary");
+// 	d = nodes_all[id-1];
+
+// 	delete_children_boxes(d);
+// 	if (d.children) {
+// 		if (!d.replace) {
+// 			d.replace = [];
+// 		}
+// 		var newchildren = [];
+// 		for (var i=0; i<d.children.length; i++) {
+// 			if (!d.children[i].summarized==false) {
+// 				d.replace.push(d.children[i]);
+// 			} else {
+// 				newchildren.push(d.children[i]);
+// 			}
+// 		}
+// 		d.children = newchildren;
+// 		update(d);
+// 	}
+// 	text = '';
+// 	if (comment_id != d.d_id) {
+// 		text += '<a href="/subtree?article=' + article_url + '&comment_id=' + d.d_id + '&num=' + num + '&owner=' + owner + '">See Isolated Subtree</a>';
+// 		text += '<BR><a onclick="expand_all(' + d.id + ')">Expand everything</a>';
+// 	}
+// 	if (text != '') {
+// 		$('#expand').html(text);
+// 	} else {
+// 		$('#expand').html("");
+// 	}
+// }
 
 function show_replace_nodes(id) {
 	d = nodes_all[id-1];
@@ -4287,6 +4325,7 @@ function show_replace_nodes(id) {
 		if (!d.children) {
 			d.children = [];
 		}
+
 		for (var i=0; i<d.replace.length; i++) {
 			d.children.push(d.replace[i]);
 		}
@@ -4313,6 +4352,22 @@ function recurse_mark_hiddennode(d) {
 		for (var i=0; i<d.children.length; i++) {
 			d.children[i].hiddennode = true;
 			recurse_mark_hiddennode(d.children[i]);
+		}
+	}
+}
+
+function mark_children_summarized(d) {
+	d.summarized = true;
+	if (d.children) {
+		for (var i=0; i<d.children.length; i++) {
+			d.children[i].summarized = true;
+			mark_children_summarized(d.children[i]);
+		}
+	}
+	if (d.replace) {
+		for (var i=0; i<d.replace.length; i++) {
+			d.replace[i].summarized = true;
+			mark_children_summarized(d.replace[i]);
 		}
 	}
 }

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -3568,6 +3568,7 @@ function construct_comment(d) {
 	var summary = !!(d.summary != '' || d.extra_summary != '');
 
 	text += `<div id="comment_text_${d.id}">`;
+	text += `<div class="id_val">#${d.id}</div>`;
 
 	if (summary) {
 		if (d.replace_node) {

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -383,6 +383,15 @@ $('#reply_modal_box').on('show.bs.modal', function(e) {
 
 
 $('#evaluate_summary_modal_box').on('show.bs.modal', function(e) {
+	$("#evaluate_summary_modal_box").css({
+	    'margin-top': function () {
+	        return ($(this).height() / 4);
+	    },
+	    'margin-left': function () {
+	        return ($(this).width() / 4);
+	    }
+	});
+	
 	var id = $(e.relatedTarget).data('id');
 	
 	d = nodes_all[id-1];
@@ -407,7 +416,37 @@ $('#evaluate_summary_modal_box').on('show.bs.modal', function(e) {
 			
 	var text = '<div class="summary_box tag_comment_comment">' + node_text+ '</div>';
 
-	$('#evaluate_summary_box').html(text);
+	if (d.replace.length > 0) {
+		var children_text = '';
+		for (var i=0; i<d.replace.length; i++) {
+			if (d.replace[i].summary != '') {
+				children_text += '<div id="sum_box_' + d.replace[i].id + '" class="summarize_comment_comment"><P>ID: ' + d.replace[i].d_id + ' | <a class="btn-xs btn-edit" onclick="copy_summary(' + d.replace[i].id + ');">Copy Entire Summary</a> | <a class="btn-xs btn-edit" onclick="cite_comment(' + d.replace[i].d_id +');">Cite Comment</a></P><strong>Summary: </strong> ' + render_summary_node_edit(d.replace[i]) + '</div>';
+			} else {
+
+				current_summarize_d_id.push(d.replace[i].d_id);
+
+				children_text += '<div id="sum_box_' + d.replace[i].id + '" class="summarize_comment_comment"><P>ID: ' + d.replace[i].d_id + ' | <a class="btn-xs btn-edit" onclick="cite_comment(' + d.replace[i].d_id +');">Cite Comment</a></P>' + show_comment_text(d.replace[i].name, d.replace[i].d_id)  + '<P>-- ' + d.replace[i].author + '</P></div>';
+			}
+			children_text = get_subtree_summarize(children_text, d.replace[i], 1);
+		}
+
+	} else if (d.children.length > 0) {
+		var children_text = '';
+		for (var i=0; i<d.children.length; i++) {
+			if (d.children[i].summary != '') {
+				children_text += '<div id="sum_box_' + d.children[i].id + '" class="summarize_comment_comment"><P>ID: ' + d.children[i].d_id + ' | <a class="btn-xs btn-edit" onclick="copy_summary(' + d.children[i].id + ');">Copy Entire Summary</a> | <a class="btn-xs btn-edit" onclick="cite_comment(' + d.children[i].d_id +');">Cite Comment</a></P><strong>Summary: </strong> ' + render_summary_node_edit(d.children[i]) + '</div>';
+			} else {
+
+				current_summarize_d_id.push(d.children[i].d_id);
+
+				children_text += '<div id="sum_box_' + d.children[i].id + '" class="summarize_comment_comment"><P>ID: ' + d.children[i].d_id + ' | <a class="btn-xs btn-edit" onclick="cite_comment(' + d.children[i].d_id +');">Cite Comment</a></P>' + show_comment_text(d.children[i].name, d.children[i].d_id) + '<P>-- ' + d.children[i].author + '</P></div>';
+			}
+			children_text = get_subtree_summarize(children_text, d.children[i], 1);
+		}
+	}
+
+	$('#evaluate_summary_box').html(text+children_text);
+	
 	var neutral = 3;
 	var coverage = 3;
 	var quality = 3;

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -351,6 +351,7 @@ $('#reply_modal_box').on('show.bs.modal', function(e) {
 							 y: d.y,
 							 y0: d.y0,
 							};
+				recurse_expand_all(d);
 				if (!d.children) {
 					d.children = [];
 				}
@@ -359,7 +360,7 @@ $('#reply_modal_box').on('show.bs.modal', function(e) {
 				}
 				d.children.push(new_d);
 				d._children.push(new_d);
-				update(d.parent);
+				update(d);
 
 				var text = construct_comment(new_d);
 				$('#comment_' + new_d.d_id).html(text);
@@ -3182,7 +3183,6 @@ function check_clicked_node(d, clicked_ids) {
 }
 
 function update(source) {
-  
 
   // Compute the flattened node list. TODO use d3.layout.hierarchy.
   var nodes = tree.nodes(root);
@@ -4486,7 +4486,11 @@ function color(d) {
 			return "#ffffff";
 		}
 	
-		if (d.collapsed && d.summarized) {
+		if (d.collapsed) {
+			if (d.summarized==false) {
+				return "#a1c5d1";
+			}
+
 			if (d.summary) {
 				return "url(#gradientorange)";
 			}

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -335,6 +335,7 @@ $('#reply_modal_box').on('show.bs.modal', function(e) {
 				new_d = {d_id: res.d_id,
 							 name: res.comment,
 							 summary: "",
+							 summarized: false,
 							 extra_summary: "",
 							 parent: d,
 							 replace: [],
@@ -343,7 +344,7 @@ $('#reply_modal_box').on('show.bs.modal', function(e) {
 							 collapsed: false,
 							 replace_node: false,
 							 size: d.size,
-							 hid: d.hid,
+							 hid: [],
 							 depth: d.depth+1,
 							 x: d.x,
 							 x0: d.x0,
@@ -352,6 +353,8 @@ $('#reply_modal_box').on('show.bs.modal', function(e) {
 							};
 				if (!d.children) {
 					d.children = [];
+				}
+				if (!d._children) {
 					d._children = [];
 				}
 				d.children.push(new_d);
@@ -1668,6 +1671,7 @@ $('#summarize_multiple_modal_box').on('show.bs.modal', function(e) {
 					new_d = {d_id: res.d_id,
 							 name: "",
 							 summary: res.top_summary,
+							 summarized: true,
 							 extra_summary: res.bottom_summary,
 							 parent: lowest_d.parent,
 							 replace: children,
@@ -1771,6 +1775,7 @@ $('#summarize_multiple_modal_box').on('show.bs.modal', function(e) {
 						new_d = {d_id: res.d_id,
 							 name: "",
 							 parent: d.parent,
+							 summarized: true,
 							 replace: [d],
 							 tags: [],
 							 summary: res.top_summary,
@@ -3795,12 +3800,13 @@ function get_subtree_box(text, d, level) {
 		for (var i=0; i<d.children.length; i++) {
 			var levelClass = level > 2? "level3" : `level${level}`;
 			var summaryClass = d.children[i].replace_node? "summary_box" : "";
+			var summarized = d.children[i].summarized!=null && !d.children[i].summarized? "summarized" : "";
 			var collapsed = d.children[i].collapsed && !d.children[i].replace_node? "collapsed" : "";
 			var summary = d.children[i].summary && !d.children[i].replace_node? "summary" : "";
 			var hiddennode = d.children[i].hiddennode && !d.children[i].replace_node? "hiddennode" : "";
 
 
-			text += `<article class="comment_box ${summaryClass} ${levelClass} ${collapsed} ${summary} ${hiddennode}" id="comment_${d.children[i].id}">`;
+			text += `<article class="comment_box ${summaryClass} ${summarized} ${levelClass} ${collapsed} ${summary} ${hiddennode}" id="comment_${d.children[i].id}">`;
 
 			text +=  construct_comment(d.children[i]);
 			text += '</article>';
@@ -3876,11 +3882,12 @@ function show_text(d) {
 			text = get_subtree_box(text, d, 0);
 		} else {
 			var summaryClass = d.replace_node? "summary_box" : "";
+			var summarized = d.summarized!=null && !d.summarized? "summarized" : "";
 			var collapsed = d.collapsed && !d.replace_node? "collapsed" : "";
 			var summary = d.summary && !d.replace_node? "summary" : "";
 			var hiddennode = d.hiddennode && !d.replace_node? "hiddennode" : "";
 
-			var text = `<article class="comment_box ${summaryClass} ${collapsed} ${summary} ${hiddennode}" id="comment_${d.id}">`;
+			var text = `<article class="comment_box ${summaryClass} ${collapsed} ${summarized} ${summary} ${hiddennode}" id="comment_${d.id}">`;
 
 			if (d.depth > 1
                 	) {
@@ -3934,10 +3941,11 @@ function show_text(d) {
 			var levelClass = level > 2? "level3" : `level${level}`;
 			var summaryClass = objs[i].replace_node? "summary_box" : "";
 			var collapsed = objs[i].collapsed && !objs[i].replace_node? "collapsed" : "";
+			var summarized = objs[i].summarized!=null && !objs[i].summarized? "summarized" : "";
 			var summary = objs[i].summary && !objs[i].replace_node? "summary" : "";
 			var hiddennode = objs[i].hiddennode && !objs[i].replace_node? "hiddennode" : "";
 
-			text += `<article class="comment_box ${summaryClass} ${levelClass} ${collapsed} ${summary} ${hiddennode}" id="comment_${objs[i].id}">`;
+			text += `<article class="comment_box ${summaryClass} ${levelClass} ${collapsed} ${summarized} ${summary} ${hiddennode}" id="comment_${objs[i].id}">`;
 
 			if (!level && objs[i].depth > 1) {
 			    if (!summary)
@@ -4478,7 +4486,7 @@ function color(d) {
 			return "#ffffff";
 		}
 	
-		if (d.collapsed) {
+		if (d.collapsed && d.summarized) {
 			if (d.summary) {
 				return "url(#gradientorange)";
 			}

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -4440,6 +4440,22 @@ function hide_hidden(id) {
 	}
 }
 
+function recurse_get_unsummarized(d, unsummarized_children=[]) {
+	if (d.summarized == false) {
+		unsummarized_children.push(d);
+	}
+	if (d.replace_node && d.replace) {
+		for (var i=0; i<d.replace.length; i++) {
+			unsummarized_children = unsummarized_children.concat(recurse_get_unsummarized(d.replace[i]), unsummarized_children);
+		}
+	}
+	if (d.children) {
+		for (var i=0; i<d.children.length; i++) {
+			unsummarized_children = unsummarized_children.concat(recurse_get_unsummarized(d.children[i]), unsummarized_children);
+		}
+	}
+	return [...new Set(unsummarized_children)];
+}
 
 function hidediv(d) {
 	if (!isMouseDown && d3.select(this).classed("clicked")) {

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -4287,37 +4287,6 @@ function hide_replace_nodes(id) {
 		$('#expand').html("");
 	}
 }
-// function hide_replace_nodes(id) {
-// 	console.log("collapse summary");
-// 	d = nodes_all[id-1];
-
-// 	delete_children_boxes(d);
-// 	if (d.children) {
-// 		if (!d.replace) {
-// 			d.replace = [];
-// 		}
-// 		var newchildren = [];
-// 		for (var i=0; i<d.children.length; i++) {
-// 			if (!d.children[i].summarized==false) {
-// 				d.replace.push(d.children[i]);
-// 			} else {
-// 				newchildren.push(d.children[i]);
-// 			}
-// 		}
-// 		d.children = newchildren;
-// 		update(d);
-// 	}
-// 	text = '';
-// 	if (comment_id != d.d_id) {
-// 		text += '<a href="/subtree?article=' + article_url + '&comment_id=' + d.d_id + '&num=' + num + '&owner=' + owner + '">See Isolated Subtree</a>';
-// 		text += '<BR><a onclick="expand_all(' + d.id + ')">Expand everything</a>';
-// 	}
-// 	if (text != '') {
-// 		$('#expand').html(text);
-// 	} else {
-// 		$('#expand').html("");
-// 	}
-// }
 
 function show_replace_nodes(id) {
 	d = nodes_all[id-1];
@@ -4369,6 +4338,39 @@ function mark_children_summarized(d) {
 			d.replace[i].summarized = true;
 			mark_children_summarized(d.replace[i]);
 		}
+	}
+}
+
+function has_unsummarized_children(d) {
+	if (d.summarized == false) {
+		return true;
+	} else {
+		if (d.children) {
+			for (var i=0; i<d.children.length; i++) {
+				return false || has_unsummarized_children(d.children[i]);
+			}
+		}
+		if (d.replace) {
+			for (var i=0; i<d.replace.length; i++) {
+				return false || has_unsummarized_children(d.replace[i]);
+			}
+		}
+		return false;
+	}
+}
+
+function expand_unsummarized_children(d) {
+	if (d.replace_node && d.replace) {
+		for (var i=0; i<d.replace.length; i++) {
+			if (!d.children) {
+				d.children = [];
+			}
+			if (has_unsummarized_children(d.replace[i])) {
+				d.children.push(d.replace[i]);
+				d.replace.splice(i, 1);
+			}
+		}
+		update(d);
 	}
 }
 

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -4618,6 +4618,20 @@ gradientorange.append("svg:stop")
     .attr("stop-color", "#ffffff")
     .attr("stop-opacity", 1);
 
+var half_orange_blue = svg.append("svg:defs")
+	.append("svg:linearGradient")
+	.attr("id", "half_orange_blue")
+	.attr("x1", "100%")
+    .attr("y1", "100%")
+    .attr("x2", "0%")
+    .attr("y2", "0%");
+half_orange_blue.append("svg:stop")
+    .attr("offset", "50%")
+    .attr("stop-color", "#a1c5d1");
+half_orange_blue.append("svg:stop")
+    .attr("offset", "50%")
+    .attr("stop-color", "#ee7600");
+
 
 var stringToColour = function(str) {
   var hash = 0;
@@ -4639,7 +4653,11 @@ function color(d) {
 		}
 	
 		if (d.replace_node) {
-			return "#ee7600";
+			if (recurse_get_unsummarized(d).length > 0) {
+				return "url(#half_orange_blue)";
+			} else {
+				return "#ee7600";
+			}
 		}
 	
 		if (d.article) {

--- a/wikum/website/static/website/js/visualization.js
+++ b/wikum/website/static/website/js/visualization.js
@@ -236,25 +236,6 @@ var comment_id = null;
 
  make_username_typeahead();
 
-unsummarized_children = [];
-function recurse_get_unsummarized(d) {
-	if (d.summarized == false) {
-		unsummarized_children.push(d);
-	}
-	if (d.replace_node && d.replace) {
-		for (var i=0; i<d.replace.length; i++) {
-			unsummarized_children.concat(recurse_get_unsummarized(d.replace[i]));
-		}
-	}
-	if (d.children) {
-		for (var i=0; i<d.children.length; i++) {
-			unsummarized_children.concat(recurse_get_unsummarized(d.children[i]));
-		}
-	}
-	return unsummarized_children;
-}
-
-
 d3.json(`/viz_data?article=${article_url}&sort=${sort}&next=${next}&num=${num}&filter=${filter}&owner=${owner}`, function(error, flare) {
 	if (error) throw error;
 

--- a/wikum/website/static/website/js/visualization.js
+++ b/wikum/website/static/website/js/visualization.js
@@ -246,7 +246,7 @@ d3.json(`/viz_data?article=${article_url}&sort=${sort}&next=${next}&num=${num}&f
 
   	update(root = flare);
   	
-	show_all_unsummarized(nodes_all[0]);
+	// show_all_unsummarized(nodes_all[0]);
 
   	show_text(nodes_all[0]);
 

--- a/wikum/website/static/website/js/visualization.js
+++ b/wikum/website/static/website/js/visualization.js
@@ -26,7 +26,6 @@ var svg = d3.select("#viz").append("svg")
   .append("g")
     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
-
 svg.append('svg:rect')
   .attr('width',  width + margin.left + margin.right) // the whole width of g/svg
   .attr('fill', 'none')
@@ -237,17 +236,68 @@ var comment_id = null;
 
  make_username_typeahead();
 
+unsummarized_children = [];
+function recurse_get_unsummarized(d) {
+	if (d.summarized == false) {
+		unsummarized_children.push(d);
+	}
+	if (d.replace_node && d.replace) {
+		for (var i=0; i<d.replace.length; i++) {
+			unsummarized_children.concat(recurse_get_unsummarized(d.replace[i]));
+		}
+	}
+	if (d.children) {
+		for (var i=0; i<d.children.length; i++) {
+			unsummarized_children.concat(recurse_get_unsummarized(d.children[i]));
+		}
+	}
+	return unsummarized_children;
+}
+
+
 d3.json(`/viz_data?article=${article_url}&sort=${sort}&next=${next}&num=${num}&filter=${filter}&owner=${owner}`, function(error, flare) {
-  if (error) throw error;
+	if (error) throw error;
 
-  flare.x0 = 100;
-  flare.y0 = 100;
+  	flare.x0 = 100;
+  	flare.y0 = 100;
 
-  nodes_all = tree.nodes(flare);
+  	nodes_all = tree.nodes(flare);
 
-  update(root = flare);
+  	update(root = flare);
 
-  show_text(nodes_all[0]);
+  	show_text(nodes_all[0]);
+
+  	// if (nodes_all[0].children) {
+  	// 	for (var i=0; i<nodes_all[0].children.length; i++) {
+  	// 		if (nodes_all[0].children[i].replace_node && nodes_all[0].children[i].replace) {
+  	// 			for (var j=0; j<nodes_all[0].children[i].replace.length; j++) {
+  	// 				if (!nodes_all[0].children[i].children) {
+  	// 					nodes_all[0].children[i].children = [];
+  	// 				}
+  	// 				unsummarized_children = [];
+	  // 				if (recurse_get_unsummarized(nodes_all[0].children[i].replace[j]) > 0) {
+	  // 					nodes_all[0].children[i].children.push(nodes_all[0].children[i].replace[j]);
+	  // 				} else {
+	  // 					nodes_all[0].children[i].replace.splice(nodes_all[0].children[i].replace[j], 1);
+	  // 				}
+  	// 			}
+  	// 		}
+  	// 	}
+  	// }
+
+  // 	console.log(nodes_all[0].children);
+  // 	if (nodes_all[0].children) {
+  // 		console.log("reached here");
+		// for (var i=0; i<nodes_all[0].children.length; i++) {
+		// 	if (nodes_all[0].children[i].replace_node) {
+		// 		unsummarized_children = [];
+		// 		recurse_get_unsummarized(nodes_all[0].children[i]);
+		// 		for (var i=0; i<unsummarized_children.length; i++) {
+		// 			nodes_all[0].children[i].
+		// 		}
+		// 	}
+		// }
+  // 	}
 
 	make_progress_bar();
   

--- a/wikum/website/static/website/js/visualization.js
+++ b/wikum/website/static/website/js/visualization.js
@@ -246,11 +246,8 @@ d3.json(`/viz_data?article=${article_url}&sort=${sort}&next=${next}&num=${num}&f
 
   	update(root = flare);
   	
-  	if (nodes_all[0].children) {
-  		for (var i=0; i<nodes_all[0].children.length; i++) {
-  			expand_unsummarized_children(nodes_all[0].children[i]);
-  		}
-  	}
+	show_all_unsummarized(nodes_all[0]);
+
   	show_text(nodes_all[0]);
 
 	make_progress_bar();

--- a/wikum/website/static/website/js/visualization.js
+++ b/wikum/website/static/website/js/visualization.js
@@ -264,40 +264,13 @@ d3.json(`/viz_data?article=${article_url}&sort=${sort}&next=${next}&num=${num}&f
   	nodes_all = tree.nodes(flare);
 
   	update(root = flare);
-
+  	
+  	if (nodes_all[0].children) {
+  		for (var i=0; i<nodes_all[0].children.length; i++) {
+  			expand_unsummarized_children(nodes_all[0].children[i]);
+  		}
+  	}
   	show_text(nodes_all[0]);
-
-  	// if (nodes_all[0].children) {
-  	// 	for (var i=0; i<nodes_all[0].children.length; i++) {
-  	// 		if (nodes_all[0].children[i].replace_node && nodes_all[0].children[i].replace) {
-  	// 			for (var j=0; j<nodes_all[0].children[i].replace.length; j++) {
-  	// 				if (!nodes_all[0].children[i].children) {
-  	// 					nodes_all[0].children[i].children = [];
-  	// 				}
-  	// 				unsummarized_children = [];
-	  // 				if (recurse_get_unsummarized(nodes_all[0].children[i].replace[j]) > 0) {
-	  // 					nodes_all[0].children[i].children.push(nodes_all[0].children[i].replace[j]);
-	  // 				} else {
-	  // 					nodes_all[0].children[i].replace.splice(nodes_all[0].children[i].replace[j], 1);
-	  // 				}
-  	// 			}
-  	// 		}
-  	// 	}
-  	// }
-
-  // 	console.log(nodes_all[0].children);
-  // 	if (nodes_all[0].children) {
-  // 		console.log("reached here");
-		// for (var i=0; i<nodes_all[0].children.length; i++) {
-		// 	if (nodes_all[0].children[i].replace_node) {
-		// 		unsummarized_children = [];
-		// 		recurse_get_unsummarized(nodes_all[0].children[i]);
-		// 		for (var i=0; i<unsummarized_children.length; i++) {
-		// 			nodes_all[0].children[i].
-		// 		}
-		// 	}
-		// }
-  // 	}
 
 	make_progress_bar();
   

--- a/wikum/website/templates/website/viz.html
+++ b/wikum/website/templates/website/viz.html
@@ -10,7 +10,8 @@
 
 <div id="author_info"></div>
 <div id="new_node">
-	<button type="button" class="btn btn-default" id="create_new" onclick="">{% trans "+" %}</button>
+	<button type="button" class="btn btn-default" data-toggle="modal" data-backdrop="false"
+	data-target="#new_node_modal_box" id="create_new">{% trans "+" %}</button>
 </div>
 <div id="viz">
 </div>
@@ -91,6 +92,29 @@
 		<button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>
 	  </div>
   </form>
+
+  </div>
+</div>
+
+<div id="new_node_modal_box" class="modal fade" role="dialog">
+  <div class="modal-dialog">
+
+	<!-- Modal content-->
+	<form class="modal-content" action="/new_node" method="POST">
+	  <div class="modal-header">
+		<button type="button" class="close" data-dismiss="modal">&times;</button>
+		<h4 class="modal-title">{% trans "New Comment" %}</h4>
+	  </div>
+	  <div class="modal-body">
+		<P>{% trans "Add a comment:" %}<BR>
+			<textarea id="new_node_textarea"></textarea>
+		</P>
+	  </div>
+	  <div class="modal-footer">
+		<button type="submit" class="btn btn-default">{% trans "Submit" %}</button>
+		<button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>
+	  </div>
+	</form>
 
   </div>
 </div>

--- a/wikum/website/templates/website/viz.html
+++ b/wikum/website/templates/website/viz.html
@@ -270,7 +270,7 @@
 </div>
 
 <div id="evaluate_summary_modal_box" class="modal fade" role="dialog">
-  <div class="modal-dialog">
+  <div class="modal-dialog" style="width: 100%; height: 100%; margin: 0px;">
 
 	<!-- Modal content-->
 	<form class="modal-content" action="/rate_summary" method="POST">
@@ -278,23 +278,30 @@
 		<button type="button" class="close" data-dismiss="modal">&times;</button>
 		<h4 class="modal-title">Evaluate Summary</h4>
 	  </div>
-	  <div class="modal-body" style="min-height: 200px;">
-	  	<div id="evaluate_text"></div>
-	  	<div id="evaluate_summary_box"></div>
-	  		  	<BR>
-	  	Neutrality: <span id="neutral_score" class="score">None</span> <BR>
-	  	
-		<div id="neutral_rating"></div>
-		<BR>
-	  	Accuracy/Representativeness: <span id="coverage_score" class="score">None</span><BR>
-	  	
-		<div id="coverage_rating"></div>
-		
-		<BR>
-	  	Writing Quality: <span id="quality_score" class="score">None</span><BR>
-		<div id="quality_rating"></div>
-		<div id="summarized_children"></div>
+
+	  <div class="modal-body">
+	  	<table style="width: 100%; height: 100%; table-layout: fixed;">
+	  		<tr><td width="50%" height="100%">
+		  		<div id="evaluate_summary_box"></div>
+		  	</td>
+		  	
+		  	<td width="50%" height="100%">
+		  		<div id="evaluate_text"></div>
+		  		Neutrality: <span id="neutral_score" class="score">None</span> <BR>
+				<div id="neutral_rating"></div>
+				<BR>
+			  	Accuracy/Representativeness: <span id="coverage_score" class="score">None</span><BR>
+			  	
+				<div id="coverage_rating"></div>
+				
+				<BR>
+			  	Writing Quality: <span id="quality_score" class="score">None</span><BR>
+				<div id="quality_rating"></div>
+				<div id="summarized_children"></div>
+			</td></tr>
+		</table>
 	</div>
+
 	  <div class="modal-footer">
 		<button type="submit" class="btn btn-default">{% trans "Submit" %}</button>
 		<button type="button" class="btn btn-default" data-dismiss="modal">{% trans "Close" %}</button>

--- a/wikum/website/templates/website/viz.html
+++ b/wikum/website/templates/website/viz.html
@@ -293,7 +293,7 @@
 		<BR>
 	  	Writing Quality: <span id="quality_score" class="score">None</span><BR>
 		<div id="quality_rating"></div>
-		<div id="unsummarized_children"></div>
+		<div id="summarized_children"></div>
 	</div>
 	  <div class="modal-footer">
 		<button type="submit" class="btn btn-default">{% trans "Submit" %}</button>

--- a/wikum/website/templates/website/viz.html
+++ b/wikum/website/templates/website/viz.html
@@ -282,20 +282,18 @@
 	  	<div id="evaluate_text"></div>
 	  	<div id="evaluate_summary_box"></div>
 	  		  	<BR>
-	  	Neutrality:<BR>
+	  	Neutrality: <span id="neutral_score" class="score">None</span> <BR>
 	  	
 		<div id="neutral_rating"></div>
-		Current status: <span id="neutral_score" class="score">None</span><BR>
 		<BR>
-	  	Accuracy/Representativeness:<BR>
+	  	Accuracy/Representativeness: <span id="coverage_score" class="score">None</span><BR>
 	  	
 		<div id="coverage_rating"></div>
-		Current status: <span id="coverage_score" class="score">None</span><BR>
 		
 		<BR>
-	  	Writing Quality:<BR>
+	  	Writing Quality: <span id="quality_score" class="score">None</span><BR>
 		<div id="quality_rating"></div>
-		Current status: <span id="quality_score" class="score">None</span><BR>
+		<div id="unsummarized_children"></div>
 	</div>
 	  <div class="modal-footer">
 		<button type="submit" class="btn btn-default">{% trans "Submit" %}</button>

--- a/wikum/website/templates/website/viz.html
+++ b/wikum/website/templates/website/viz.html
@@ -9,7 +9,11 @@
 	</label>
 
 <div id="author_info"></div>
-<div id="viz"></div>
+<div id="new_node">
+	<button type="button" class="btn btn-default" id="create_new" onclick="">{% trans "+" %}</button>
+</div>
+<div id="viz">
+</div>
 <div id="box"></div>
 
 <div id="expand" style="display: none;"></div>

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -377,6 +377,7 @@ def summary_data(request):
     
     
     val2 = {}
+    # recurse_viz(parent, posts, replaced, article, is_collapsed)
     val2['children'], val2['hid'], val2['replace'], num_subchildren = recurse_viz(None, posts, False, a, False)
     
     return JsonResponse({'posts': val2})
@@ -464,6 +465,7 @@ def mark_children_summarized(post):
         mark_children_summarized(child)
 
 def remove_summarized(post):
+    print("remove summarized")
     post.summarized = False
     children = Comment.objects.filter(reply_to_disqus=post.disqus_id, article=post.article)
     for child in children:
@@ -471,7 +473,7 @@ def remove_summarized(post):
             child.summarized = False
             print(child.text)
             child.save()
-            mark_children_summarized(child)
+            remove_summarized(child)
     
 def clean_parse(text):
     text = parse(text).strip()
@@ -589,12 +591,15 @@ def recurse_viz(parent, posts, replaced, article, is_collapsed):
             
             c1 = reps.filter(reply_to_disqus=post.disqus_id).order_by('-points')
             if c1.count() == 0:
+                print('OTHER HERE')
                 vals = []
                 hid = []
                 rep = []
                 num_subchildren = 0
             else:
+                print('RECURSE HERE')
                 replace_future = replaced or post.is_replacement
+                # recurse_viz(parent, posts, replaced, article, is_collapsed)
                 vals, hid, rep, num_subchildren = recurse_viz(post, c1, replace_future, article, is_collapsed or post.is_replacement)
             v1['children'] = vals
             v1['hid'] = hid
@@ -611,10 +616,13 @@ def recurse_viz(parent, posts, replaced, article, is_collapsed):
             v1 = json.loads(post.json_flatten)
         
         if post.hidden:
+            print("hidden")
             hid_children.append(v1)
-        elif parent and parent.is_replacement:
+        elif parent and parent.is_replacement and post.summarized:
+            print("summarized and collapsed")
             replace_children.append(v1)
         else:
+            print("shown children")
             children.append(v1)
             
     return children, hid_children, replace_children, num_subtree_children
@@ -856,6 +864,7 @@ def delete_node(did):
         article = c.article
         
         if c.is_replacement:
+            remove_summarized(c)
             parent = Comment.objects.filter(disqus_id=c.reply_to_disqus, article=article)
             
             if parent.count() > 0:
@@ -927,8 +936,12 @@ def summarize_comments(request):
                                        explanation='initial summary of subtree')
             
             d_id = new_comment.id
-            
+
             h.comments.add(new_comment)
+
+            mark_children_summarized(new_comment)
+
+            recurse_up_post(new_comment)
 
             recurse_down_num_subtree(new_comment)
             
@@ -949,6 +962,7 @@ def summarize_comments(request):
             
             new_comment = c
             recurse_down_num_subtree(new_comment)
+            recurse_up_post(c)
         
         
         for node in delete_nodes:
@@ -962,9 +976,8 @@ def summarize_comments(request):
 
       
         h.comments.add(c)
-        recurse_up_post(c)
         
-        mark_children_summarized(c)
+        
         make_vector(new_comment, a)
         
         a.summary_num = a.summary_num + 1
@@ -1792,7 +1805,7 @@ def users(request):
 def determine_is_collapsed(post, article):
     parent = Comment.objects.filter(disqus_id=post.reply_to_disqus, article=article)
     if parent.count() > 0:
-        if parent[0].is_replacement:
+        if parent[0].is_replacement and post.summarized:
             return True
         else:
             return determine_is_collapsed(parent[0], article)
@@ -1883,7 +1896,8 @@ def viz_data(request):
             val2 = {}
             
             is_collapsed = determine_is_collapsed(post, a)
-            
+
+            # recurse_viz(parent, posts, replaced, article, is_collapsed)
             val2['children'], val2['hid'], val2['replace'], num_subchildren = recurse_viz(None, [post], False, a, is_collapsed)
             
             val_child = recurse_get_parents(val2, post, a)
@@ -1905,6 +1919,7 @@ def viz_data(request):
         elif sort == 'oldest':
             posts = a.comment_set.filter(reply_to_disqus=None).order_by('created_at')[start:end]
         
+        # recurse_viz(parent, posts, replaced, article, is_collapsed)
         val['children'], val['hid'], val['replace'], num_subchildren = recurse_viz(None, posts, False, a, False)
         
     return JsonResponse(val)
@@ -2010,6 +2025,7 @@ def cluster_data(request):
         if cluster == min_cluster:
             posts_cluster.append(post)
     
+    # recurse_viz(parent, posts, replaced, article, is_collapsed)
     val['children'], val['hid'], val['replace'], num_subchildren = recurse_viz(None, posts_cluster, False, a, False)
     
     return JsonResponse(val)
@@ -2073,7 +2089,8 @@ def subtree_data(request):
         val2 = {}
         
         is_collapsed = determine_is_collapsed(posts[0], a)
-        
+
+        # recurse_viz(parent, posts, replaced, article, is_collapsed)        
         val2['children'], val2['hid'], val2['replace'], num_subchildren = recurse_viz(None, posts, False, a, is_collapsed)
         
         val = recurse_get_parents(val2, posts[0], a)

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -1352,6 +1352,12 @@ def rate_summary(request):
             c.summarized = True
             c.save()
             recurse_up_post(c)
+        mark_dids = request.POST.getlist('mark_dids[]')
+        mark_selected = Comment.objects.filter(id__in=mark_dids)
+        for c in mark_selected:
+            c.summarized = False
+            c.save()
+            recurse_up_post(c)
     
         comment = Comment.objects.get(id=id)
     

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -377,7 +377,6 @@ def summary_data(request):
     
     
     val2 = {}
-    # recurse_viz(parent, posts, replaced, article, is_collapsed)
     val2['children'], val2['hid'], val2['replace'], num_subchildren = recurse_viz(None, posts, False, a, False)
     
     return JsonResponse({'posts': val2})
@@ -460,18 +459,15 @@ def mark_children_summarized(post):
     children = Comment.objects.filter(reply_to_disqus=post.disqus_id, article=post.article)
     for child in children:
         child.summarized = True
-        print(child.text)
         child.save()
         mark_children_summarized(child)
 
 def remove_summarized(post):
-    print("remove summarized")
     post.summarized = False
     children = Comment.objects.filter(reply_to_disqus=post.disqus_id, article=post.article)
     for child in children:
         if not child.is_replacement:
             child.summarized = False
-            print(child.text)
             child.save()
             remove_summarized(child)
     
@@ -591,15 +587,12 @@ def recurse_viz(parent, posts, replaced, article, is_collapsed):
             
             c1 = reps.filter(reply_to_disqus=post.disqus_id).order_by('-points')
             if c1.count() == 0:
-                print('OTHER HERE')
                 vals = []
                 hid = []
                 rep = []
                 num_subchildren = 0
             else:
-                print('RECURSE HERE')
                 replace_future = replaced or post.is_replacement
-                # recurse_viz(parent, posts, replaced, article, is_collapsed)
                 vals, hid, rep, num_subchildren = recurse_viz(post, c1, replace_future, article, is_collapsed or post.is_replacement)
             v1['children'] = vals
             v1['hid'] = hid
@@ -616,13 +609,10 @@ def recurse_viz(parent, posts, replaced, article, is_collapsed):
             v1 = json.loads(post.json_flatten)
         
         if post.hidden:
-            print("hidden")
             hid_children.append(v1)
         elif parent and parent.is_replacement and post.summarized:
-            print("summarized and collapsed")
             replace_children.append(v1)
         else:
-            print("shown children")
             children.append(v1)
             
     return children, hid_children, replace_children, num_subtree_children
@@ -1897,7 +1887,6 @@ def viz_data(request):
             
             is_collapsed = determine_is_collapsed(post, a)
 
-            # recurse_viz(parent, posts, replaced, article, is_collapsed)
             val2['children'], val2['hid'], val2['replace'], num_subchildren = recurse_viz(None, [post], False, a, is_collapsed)
             
             val_child = recurse_get_parents(val2, post, a)
@@ -1919,7 +1908,6 @@ def viz_data(request):
         elif sort == 'oldest':
             posts = a.comment_set.filter(reply_to_disqus=None).order_by('created_at')[start:end]
         
-        # recurse_viz(parent, posts, replaced, article, is_collapsed)
         val['children'], val['hid'], val['replace'], num_subchildren = recurse_viz(None, posts, False, a, False)
         
     return JsonResponse(val)
@@ -2025,7 +2013,6 @@ def cluster_data(request):
         if cluster == min_cluster:
             posts_cluster.append(post)
     
-    # recurse_viz(parent, posts, replaced, article, is_collapsed)
     val['children'], val['hid'], val['replace'], num_subchildren = recurse_viz(None, posts_cluster, False, a, False)
     
     return JsonResponse(val)
@@ -2089,8 +2076,7 @@ def subtree_data(request):
         val2 = {}
         
         is_collapsed = determine_is_collapsed(posts[0], a)
-
-        # recurse_viz(parent, posts, replaced, article, is_collapsed)        
+        
         val2['children'], val2['hid'], val2['replace'], num_subchildren = recurse_viz(None, posts, False, a, is_collapsed)
         
         val = recurse_get_parents(val2, posts[0], a)

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -1346,6 +1346,12 @@ def rate_summary(request):
         neutral_rating = request.POST['neu']
         coverage_rating = request.POST['cov']
         quality_rating = request.POST['qual']
+        selected_dids = request.POST.getlist('selected_dids[]')
+        selected = Comment.objects.filter(id__in=selected_dids)
+        for c in selected:
+            c.summarized = True
+            c.save()
+            recurse_up_post(c)
     
         comment = Comment.objects.get(id=id)
     

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -462,6 +462,16 @@ def mark_children_summarized(post):
         print(child.text)
         child.save()
         mark_children_summarized(child)
+
+def remove_summarized(post):
+    post.summarized = False
+    children = Comment.objects.filter(reply_to_disqus=post.disqus_id, article=post.article)
+    for child in children:
+        if not child.is_replacement:
+            child.summarized = False
+            print(child.text)
+            child.save()
+            mark_children_summarized(child)
     
 def clean_parse(text):
     text = parse(text).strip()

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -1346,15 +1346,15 @@ def rate_summary(request):
         neutral_rating = request.POST['neu']
         coverage_rating = request.POST['cov']
         quality_rating = request.POST['qual']
-        selected_dids = request.POST.getlist('selected_dids[]')
-        selected = Comment.objects.filter(id__in=selected_dids)
-        for c in selected:
+        to_summarize_dids = request.POST.getlist('to_summarize_dids[]')
+        to_unsummarize_dids = request.POST.getlist('to_unsummarize_dids[]')
+        summarize_dids = Comment.objects.filter(id__in=to_summarize_dids)
+        for c in summarize_dids:
             c.summarized = True
             c.save()
             recurse_up_post(c)
-        mark_dids = request.POST.getlist('mark_dids[]')
-        mark_selected = Comment.objects.filter(id__in=mark_dids)
-        for c in mark_selected:
+        unsummarize_dids = Comment.objects.filter(id__in=to_unsummarize_dids)
+        for c in unsummarize_dids:
             c.summarized = False
             c.save()
             recurse_up_post(c)

--- a/wikum/wikum/urls.py
+++ b/wikum/wikum/urls.py
@@ -90,6 +90,7 @@ urlpatterns = [
     url(r'^summarize_comments','website.views.summarize_comments'),
     url(r'^summarize_comment','website.views.summarize_comment'),
     url(r'^reply_comment','website.views.reply_comment'),
+    url(r'^new_node','website.views.new_node'),
     
     url(r"^account/", include("account.urls")),
     url(r'^admin/', admin.site.urls),


### PR DESCRIPTION
- On page load (and when clicking View: All Comments), all branches with summarized comments are expanded
- Each comment now has a visible id in the top left corner
- Evaluate Summary modal now allows adding and removing from unsummarized list
   - Add drop down: shows summarized children ids (recursively) and selecting one will mark it as unsummarized (and save)
   - Unsummarized list: shows all unsummarized children ids (recursively) and selecting multiple will mark those are summarized (and save)