### PR TITLE
Fixes to Outline View

### DIFF
--- a/wikum/website/consumers.py
+++ b/wikum/website/consumers.py
@@ -36,6 +36,7 @@ class WikumConsumer(WebsocketConsumer):
         Called when the websocket is handshaking as part of initial connection.
         """
         # message['path'] = /ws/article/[article_name]/visualization_flags
+        # message['path'] = /ws/article/[article_name]/subtree
         self.article_id = self.scope['url_route']['kwargs']['article_id']
         self.group_name = 'article_%s' % self.article_id
         self.user_to_locked_nodes = {}

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -494,6 +494,10 @@ textarea {
 	padding-left: 5px;
 }
 
+#outline .outline-title:hover {
+	cursor: pointer;
+}
+
 #outline .outline-text:hover {
 	cursor: pointer;
 	background-color: #D3D3D3;

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -390,6 +390,7 @@ textarea {
 	display: flex;
 	flex-direction: row;
 	position: relative;
+	width: 18vw;
 }
 
 #outline .list-group-line {
@@ -404,11 +405,11 @@ textarea {
 }
 
 #outline .list-group-line.line-hover {
-	background-color: red;
+	background-color: black;
 }
 
 #outline .list-group-line.outline-selected {
-	background-color: red;
+	background-color: black;
 }
 
 
@@ -467,7 +468,7 @@ textarea {
 }
 
 #outline .marker.outline-selected {
-	border: 1.5px solid red;
+	border: 1.5px solid black;
 }
 
 #outline .m-unsum_comment {
@@ -511,10 +512,6 @@ textarea {
 
 .outline-item #down-arrow:hover {
 	cursor: pointer;
-}
-
-.rb-red {
-	/* font-weight: bold; */
 }
 
 text {

--- a/wikum/website/static/website/css/base-vis.css
+++ b/wikum/website/static/website/css/base-vis.css
@@ -390,7 +390,6 @@ textarea {
 	display: flex;
 	flex-direction: row;
 	position: relative;
-	width: 18vw;
 }
 
 #outline .list-group-line {

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -3535,7 +3535,8 @@ function getState(d) {
 
 function stripHtml(text) {
 	var stripped = text.replace(/<[^>]*>?/gm, '');
-	return stripped.replace(/\"/g, "");
+	stripped = stripped.replace(/\"/g, "");
+	return stripped.replace('[quote]','');
 }
 
 function shorten(text, max_length) {

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -3544,6 +3544,16 @@ function shorten(text, max_length) {
   return text.substr(0, text.lastIndexOf(' ', max_length));
 }
 
+function setMaxLength(depth) {
+	if (depth < 4) {
+		return 40;
+	} else if (4 <= depth && depth < 6) {
+		return 30;
+	} else {
+		return 20;
+	}
+}
+
 function createOutlineInsideString(d, outline='') {
 	/** type (for coloring):
 	  *  comment = normal comment
@@ -3555,7 +3565,8 @@ function createOutlineInsideString(d, outline='') {
 		outline += `<div class="list-group nested-sortable">`;
 		for (var i=0; i<d.children.length; i++) {
 			var node = d.children[i];
-			let title = node.summary? shorten(stripHtml(node.summary), 20) : shorten(stripHtml(node.name), 20);
+			var maxLength = setMaxLength(node.depth);
+			let title = node.summary? shorten(stripHtml(node.summary), maxLength) : shorten(stripHtml(node.name), maxLength);
 			let state = getState(node);
 			outline += `<div class="list-countainer">`;
 				outline += `<div class="list-group-line" id="line-${node.d_id}"> </div>`;

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -3534,7 +3534,13 @@ function getState(d) {
 }
 
 function stripHtml(text) {
-	return text.replace(/<[^>]*>?/gm, '');
+	var stripped = text.replace(/<[^>]*>?/gm, '');
+	return stripped.replace(/\"/g, "");
+}
+
+function shorten(text, max_length) {
+  if (text.length <= max_length) return text;
+  return text.substr(0, text.lastIndexOf(' ', max_length));
 }
 
 function createOutlineInsideString(d, outline='') {
@@ -3548,7 +3554,7 @@ function createOutlineInsideString(d, outline='') {
 		outline += `<div class="list-group nested-sortable">`;
 		for (var i=0; i<d.children.length; i++) {
 			var node = d.children[i];
-			let title = node.summary? stripHtml(node.summary).substring(0,20) : stripHtml(node.name).substring(0,20);
+			let title = node.summary? shorten(stripHtml(node.summary), 20) : shorten(stripHtml(node.name), 20);
 			let state = getState(node);
 			outline += `<div class="list-countainer">`;
 				outline += `<div class="list-group-line" id="line-${node.d_id}"> </div>`;

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -4658,9 +4658,7 @@ function mark_children_summarized(d) {
 }
 
 function has_unsummarized_children(d) {
-	if (!d.summarized) {
-		return true;
-	} else {
+	if (d.summarized == false) {
 		// either summary node or summarized comment
 		var huc = false;
 		if (d.children) {
@@ -4679,6 +4677,8 @@ function has_unsummarized_children(d) {
 			}
 		}
 		return huc;
+	} else {
+		return true;
 	}
 }
 

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -4658,7 +4658,7 @@ function mark_children_summarized(d) {
 }
 
 function has_unsummarized_children(d) {
-	if (d.summarized == false) {
+	if (d.replace_node || d.summarized == false) {
 		// either summary node or summarized comment
 		var huc = false;
 		if (d.children) {

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -3615,7 +3615,7 @@ function createOutlineInsideString(d, outline='', depth=1) {
 function createOutlineString(d) {
 	var title = $('#wikum-title').clone().children().remove().end().text();
 	var outlineString = '<div id="nestedOutline" class="list-group col nested-sortable">';
-	outlineString += `<div id='viewAll' class='outline-item'><div class='outline-text' id='outline-text-viewAll'>${title}`;
+	outlineString += `<div id='viewAll'><div class='outline-title' id='outline-text-viewAll'>${title}`;
 	outlineString += `</div></div>`;
 	outlineString += createOutlineInsideString(d);
 	outlineString += '</div>';

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -3554,7 +3554,7 @@ function setMaxLength(depth) {
 	}
 }
 
-function createOutlineInsideString(d, outline='') {
+function createOutlineInsideString(d, outline='', depth=1) {
 	/** type (for coloring):
 	  *  comment = normal comment
 	  *  unsum = unsummarized comment under a summary node
@@ -3565,7 +3565,7 @@ function createOutlineInsideString(d, outline='') {
 		outline += `<div class="list-group nested-sortable">`;
 		for (var i=0; i<d.children.length; i++) {
 			var node = d.children[i];
-			var maxLength = setMaxLength(node.depth);
+			var maxLength = setMaxLength(depth);
 			let title = node.summary? shorten(stripHtml(node.summary), maxLength) : shorten(stripHtml(node.name), maxLength);
 			let state = getState(node);
 			outline += `<div class="list-countainer">`;
@@ -3587,7 +3587,7 @@ function createOutlineInsideString(d, outline='') {
 					outline += '<span id="down-arrow">&#9660</span>';
 				}
 				outline += `</div>`;
-				outline += createOutlineInsideString(d.children[i]);
+				outline += createOutlineInsideString(d.children[i], '', depth=depth+1);
 				outline += `</div>`;
 			outline += `</div>`;
 		}

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -4664,7 +4664,7 @@ function mark_children_summarized(d) {
 }
 
 function has_unsummarized_children(d) {
-	if (d.summarized == false) {
+	if (!d.replace_node && d.summarized == false) {
 		return true;
 	} else {
 		// either summary node or summarized comment

--- a/wikum/website/static/website/js/base_flags.js
+++ b/wikum/website/static/website/js/base_flags.js
@@ -4658,7 +4658,9 @@ function mark_children_summarized(d) {
 }
 
 function has_unsummarized_children(d) {
-	if (d.replace_node || d.summarized == false) {
+	if (d.summarized == false) {
+		return true;
+	} else {
 		// either summary node or summarized comment
 		var huc = false;
 		if (d.children) {
@@ -4677,8 +4679,6 @@ function has_unsummarized_children(d) {
 			}
 		}
 		return huc;
-	} else {
-		return true;
 	}
 }
 

--- a/wikum/website/static/website/js/subtree_outline.js
+++ b/wikum/website/static/website/js/subtree_outline.js
@@ -1,0 +1,345 @@
+var timer = null;
+var isClick = true;
+var isClick2 = true;
+var isMouseDown = false;
+var hover_timer = null;
+var highlighted_text = null;
+var highlighted_comm = null;
+var highlight_text = null;
+var ctrlIsPressed = false;
+var lastClicked = null;
+var clicked_dids = {};
+var article_id = $('#article_id').text();
+
+/* Outline View Visualization */
+
+$(document).keydown(function(evt) {
+    if (evt.ctrlKey || evt.metaKey) {
+    	ctrlIsPressed = true;
+    	clicked_dids = {};
+    } else {
+    	ctrlIsPressed = false;
+    }
+});
+
+$(document).keyup(function(evt){
+	if (evt.originalEvent.key === 'Meta' || evt.originalEvent.key === 'Control') {
+    	ctrlIsPressed = false;
+    }
+});
+
+document.addEventListener('visibilitychange', function () {
+    if (document.hidden) {
+        ctrlIsPressed = false;
+    }
+});
+
+var nodes_all = null;
+
+var article_url = $('#article_url').text();
+var owner = getParameterByName('owner');
+article_url = article_url.replace('#','%23');
+
+var sort = getParameterByName('sort');
+if (!sort) {
+	if (article_url.indexOf('wikipedia.org') !== -1) {
+		sort = "id";
+	} else {
+		sort = "likes";
+	}
+}
+var next = parseInt(getParameterByName('next'));
+if (!next) {
+	next = 0;
+}
+var num = parseInt(getParameterByName('num'));
+if (!num) {
+	num = 0;
+}
+var comment_id = parseInt(getParameterByName('comment_id'));
+if (!comment_id) {
+	comment_id = '';
+}
+var filter = getParameterByName('filter');
+if (!filter) {
+	filter = '';
+}
+var colorby = getParameterByName('colorby');
+if (!colorby) {
+	colorby = 'summarized';
+}
+
+make_stats();
+
+make_color();
+
+make_dropdown();
+
+make_filter();
+
+make_highlight();
+
+var article_id = $("#article_id").text();
+
+
+$('#menu-view').children().first().css({'background-color': '#42dca3'});	
+$('#menu-view').children().eq(0).children().first().attr('href', `/visualization_flags?id=${article_id}&owner=${owner}`);
+$('#menu-view').children().eq(1).children().first().attr('href', `/subtree?id=${article_id}&owner=${owner}`);
+$('#menu-view').children().eq(2).children().first().attr('href', `/cluster?id=${article_id}&owner=${owner}`);
+$('#menu-view').children().eq(3).children().first().attr('href', `/history?id=${article_id}&owner=${owner}`);
+$('#menu-view').children().eq(4).children().first().attr('href', article_id);
+
+make_username_typeahead();
+
+$.ajax({type: 'GET',	
+	url: '/subtree_data?id=' + article_id + '&sort=' + sort + '&next=' + next + '&owner=' + owner + '&comment_id=' + comment_id,	
+	success: function(flare) {
+		var outline = createOutlineString(flare);
+		document.getElementById("outline").innerHTML = outline;
+		setSortables();
+
+		redOutlineBorder(document.getElementById("viewAll"));
+
+		nodes_all = update_nodes_all(flare);
+		show_text(nodes_all[0]);
+		make_progress_bar();
+
+		$('body').on('mouseenter', '.marker', function() {
+			// hover gray background text
+			$(this).next().addClass('outline-hover');
+		});
+
+		$('body').on('mouseleave', '.marker', function() {
+			// circle marker in red
+			$(this).next().removeClass('outline-hover');
+		});
+
+		// .outline-text functions
+		var delay=500, setTimeoutConst;
+		$('body').on('mouseenter', '.outline-text', function() {
+			// circle marker in red
+			$(this).prev().addClass('outline-hover');
+			// highlight associated comment box
+			let did = this.id.substring(13);
+			if (did === 'viewAll') {
+				setTimeoutConst = setTimeout(function() {
+					$('#box').animate({scrollTop: 0}, 500);
+				}, delay);
+			} else {
+				let comment_box = $(".comment_box[data-did='" + did +"']");
+				if (comment_box && comment_box.length) {
+					highlight_box(comment_box[0].id.substring(8));
+					setTimeoutConst = setTimeout(function() {
+						$("#box").scrollTo("#" + comment_box[0].id, 500);
+					}, delay);
+					
+				}
+			}
+		});
+
+		$('body').on('mouseleave', '.outline-text', function() {
+			// removed red circle marker
+			$(this).prev().removeClass('outline-hover');
+			// highlight associated comment box
+			let did = this.id.substring(13);
+			if (did === 'viewAll') {
+				clearTimeout(setTimeoutConst);
+			} else {
+				let comment_box = $(".comment_box[data-did='" + did +"']");
+			
+				if (comment_box && comment_box.length) {
+					highlight_box(comment_box[0].id.substring(8));
+					clearTimeout(setTimeoutConst);
+				}
+			}
+		});
+
+		$('body').on('click', '#down-arrow', function(evt) {
+			var outlineItem = $(this).parent()[0];
+			var child = $(this).parent().next()[0];
+			let id = outlineItem.id;
+			var d = id === 'viewAll' ? nodes_all[0] : nodes_all.filter(o => o.d_id == id)[0];
+	    	if (child) {
+	    		collapse(d);
+	    	}
+	    	else {
+	    		expand(d);
+	    	}
+		});
+
+		$('body').on('click', '.list-group-line', function(evt) {
+			var selectGroup = $(this).closest('.list-group-item').children(":first").get(0);
+			d = selectGroup ? nodes_all.filter(o => o.d_id == selectGroup.id)[0] : nodes_all[0];
+			var outlineText = $(selectGroup).children('.outline-text')[0];
+			var child = $(selectGroup).next().get(0);
+			if (lastClicked === outlineText) {
+	    		if (child) {
+		    		collapse(d);
+		    	}
+		    	else {
+		    		expand(d);
+		    	}
+	    	} else {
+			    // highlight this and children
+			    redOutlineBorder(selectGroup);
+			    // show appropriate comment boxes
+			    show_text(d);
+	    	}
+	    	lastClicked = outlineText;
+		});
+
+		$('body').on('mouseenter', '.list-group-line', function(evt) {
+			$(this).closest('.list-group').children('.list-countainer').each(function () {
+				$(this).children('.list-group-line').addClass('line-hover');
+			});
+		});
+
+		$('body').on('mouseleave', '.list-group-line', function(evt) {
+			$(this).closest('.list-group').children('.list-countainer').each(function () {
+				$(this).children('.list-group-line').removeClass('line-hover');
+			});
+		});
+
+		$('body').on('click', '.outline-text, .marker', function(evt) {
+			var parent = $(this).parent();
+			var outlineText = $(this).parent().children('.outline-text')[0];
+		    if (ctrlIsPressed) {
+		    	$('.rb-red').removeClass('rb-red');
+		    	$('.outline-selected').removeClass('outline-selected');
+		    	let did = outlineText.id.substring(13);
+		    	if (did !== 'viewAll') {
+		    		let outlineItem = $(outlineText).parent()[0];
+			    	if (!(did in clicked_dids)) {
+			    		clicked_dids[did] = 1;
+			    	} else if (clicked_dids[did] === 0) {
+			    		clicked_dids[did] = 1;
+			    	} else if (clicked_dids[did] === 1) {
+			    		// clicked outline item is already in clicked_dids
+			    		clicked_dids[did] = 0;
+			    	}
+			    }
+
+			    for (const did in clicked_dids) {
+			    	if (clicked_dids[did] === 1) {
+			    		$('.outline-item#' + did).addClass('rb-red');
+			    		/* outline the circle */
+						$('#marker-' + did).addClass('outline-selected');
+			    	}
+			    }
+				show_text('clicked');
+		  		if (highlight_text) {
+		      		$('#box').highlight(highlight_text);
+		      	}
+		    } else {
+		    	var outlineItem = $(outlineText).parent()[0];
+			    var child = $(outlineText).parent().next()[0];
+			    // show only this item and children (subtree)
+				let id = outlineText.id.substring(13);
+			    d = id === 'viewAll' ? nodes_all[0] : nodes_all.filter(o => o.d_id == id)[0];
+		    	if (lastClicked === outlineText) {
+		    		if (child) {
+			    		collapse(d);
+			    	}
+			    	else {
+			    		expand(d);
+			    	}
+		    	} else {
+				    // highlight this and children
+				    redOutlineBorder(outlineItem);
+				    // show appropriate comment boxes
+				    show_text(d);
+		    	}
+		    	lastClicked = outlineText;
+		    }
+		});
+
+		var expandDelay=1000, expandSetTimeoutConst;
+		$('body').on('mouseenter', '.outline-item', function() {
+			// show #expand div
+			let id = this.id;
+			expandSetTimeoutConst = setTimeout(function() {
+					var d = id === 'viewAll' ? nodes_all[0] : nodes_all.filter(o => o.d_id == id)[0];
+					showdiv(d);
+				}, expandDelay);
+		});
+
+		$('body').on('mouseleave', '.outline-item', function() {
+			// show #expand div
+			let id = this.id;
+			var d = id === 'viewAll' ? nodes_all[0] : nodes_all.filter(o => o.d_id == id)[0];
+			hidediv(d);
+			clearTimeout(expandSetTimeoutConst);
+		});
+
+		// $('body').on('mouseleave', '#expand', function() {
+		// 	// hide #expand div if move mouse out of #outline
+		// 	$('#expand').hide();
+		// });
+
+		// viz functions
+		$('#viz').on('click', function(evt) {
+			if (!($(evt.target).hasClass('list-group-line') || $(evt.target).hasClass('list-group-item') || $(evt.target).hasClass('outline-item') || $(evt.target).hasClass('outline-text') || $(evt.target).hasClass('marker'))) {
+				redOutlineBorder($('#outline').children(":first").children('.list-group'));
+				show_text(nodes_all[0]);
+				lastClicked = $('#outline-text-viewAll');
+			}
+		});
+	},
+	error: function() {
+		error_noty();
+	}
+});
+
+function make_dropdown() {
+	var sort_num = 0;
+	if (sort == "likes") {
+		sort_num = 1;
+	} else if (sort == "replies") {
+		sort_num = 2;
+	} else if (sort == "long") {
+		sort_num = 3;
+	} else if (sort == "short") {
+		sort_num = 4;
+	} else if (sort == "newest") {
+		sort_num = 5;
+	} else if (sort == "oldest") {
+		sort_num = 6;
+	}
+
+	$('#menu-sort').children().eq(sort_num).css({'background-color': '#42dca3'});
+	$('#menu-sort').children().eq(sort_num).addClass('disabled-menu');
+
+	$('#menu-sort').children().eq(sort_num).children().first().on('click', function() {
+	    return false;
+	});
+
+	var url = "/subtree?id=" + article_id + '&owner=' + owner + '&colorby=' + colorby  + '&sort=';
+	$('#menu-sort').children().eq(0).children().first().attr('href', String(url + 'id'));
+	$('#menu-sort').children().eq(1).children().first().attr('href', String(url + 'likes'));
+	$('#menu-sort').children().eq(2).children().first().attr('href', String(url + 'replies'));
+	$('#menu-sort').children().eq(3).children().first().attr('href', String(url + 'long'));
+	$('#menu-sort').children().eq(4).children().first().attr('href', String(url + 'short'));
+	$('#menu-sort').children().eq(5).children().first().attr('href', String(url + 'newest'));
+	$('#menu-sort').children().eq(6).children().first().attr('href', String(url + 'oldest'));
+}
+
+function make_color() {
+	var color_val = 0;
+	if (colorby == "user") {
+		 color_val = 1;
+	}
+	
+	$('#menu-color').children().eq(color_val).css({'background-color': '#42dca3'});
+		 $('#menu-color').children().eq(color_val).addClass('disabled-menu');
+
+  		$('#menu-color').children().eq(color_val).children().first().on('click', function() {
+	    	return false;
+		});
+	
+	$('#menu-color').children().eq(0).children().first().attr('href', 
+		`/subtree?id=${article_id}&owner=${owner}&sort=${sort}&filter=${filter}&colorby=summarized`);
+ 
+ 	$('#menu-color').children().eq(1).children().first().attr('href', 
+		`/subtree?id=${article_id}&owner=${owner}&sort=${sort}&filter=${filter}&colorby=user`);
+
+}

--- a/wikum/website/static/website/js/summary.js
+++ b/wikum/website/static/website/js/summary.js
@@ -42,7 +42,7 @@ function display_comments(discuss_info_list, level, total_summary_text, auto_hid
 
 $(document).ready(function () {
 	
-	var article_url = getParameterByName('article');
+	var article_url = $('#article_url').text();
 	var article_id = $("#article_id").text();
 	article_url = encodeURI(article_url).replace(/%5B/g, '[').replace(/%5D/g, ']');
 	article_url = article_url.replace('#','%23').replace('&', '%26')

--- a/wikum/website/static/website/js/summary1.js
+++ b/wikum/website/static/website/js/summary1.js
@@ -41,7 +41,7 @@ function display_comments(discuss_info_list, level, total_summary_text, auto_hid
 
 $(document).ready(function () {
 	
-	var article_url = getParameterByName('article');
+	var article_url = $('#article_url').text();
 	var article_id = $("#article_id").text();
 	article_url = article_url.replace('#','%23');
 	var next = parseInt(getParameterByName('next'));

--- a/wikum/website/static/website/js/summary2.js
+++ b/wikum/website/static/website/js/summary2.js
@@ -41,7 +41,7 @@ function display_comments(discuss_info_list, level, total_summary_text, auto_hid
 
 $(document).ready(function () {
 	
-	var article_url = getParameterByName('article');
+	var article_url = $('#article_url').text();
 	var article_id = $("#article_id").text();
 	article_url = article_url.replace('#','%23');
 	var next = parseInt(getParameterByName('next'));

--- a/wikum/website/static/website/js/summary3.js
+++ b/wikum/website/static/website/js/summary3.js
@@ -41,7 +41,7 @@ function display_comments(discuss_info_list, level, total_summary_text, auto_hid
 
 $(document).ready(function () {
 	
-	var article_url = getParameterByName('article');
+	var article_url = $('#article_url').text();
 	var article_id = $("#article_id").text();
 	article_url = article_url.replace('#','%23');
 	var next = parseInt(getParameterByName('next'));

--- a/wikum/website/static/website/js/summary4.js
+++ b/wikum/website/static/website/js/summary4.js
@@ -50,7 +50,7 @@ function display_comments(discuss_info_list, level, total_summary_text, auto_hid
 
 $(document).ready(function () {
 	
-	var article_url = getParameterByName('article');
+	var article_url = $('#article_url').text();
 	var article_id = $("#article_id").text();
 	article_url = article_url.replace('#','%23');
 	var next = parseInt(getParameterByName('next'));

--- a/wikum/website/templates/website/subtree.html
+++ b/wikum/website/templates/website/subtree.html
@@ -27,6 +27,7 @@
 	<script src={% static "website/js/jquery-ui.min.js" %}></script>
 	<script src={% static "website/js/jquery.noty.packaged.min.js" %}></script>
 	<script src={% static "website/js/jquery.highlight.js" %}></script>
+	<script src={% static "website/js/sortable.min.js" %}></script>
 	<script src={% static "website/js/typeahead.bundle.js" %}></script>
 	<script src={% static "website/js/reconnecting-websocket.min.js" %}></script>
 	<script src="https://cdn.tiny.cloud/1/eows4bvgmlbllqnglakryiwa42vtmudh2l2iql3paypmptkx/tinymce/5/tinymce.min.js"></script>
@@ -43,6 +44,6 @@
     </script>
 
     <script src={% static "website/js/base_flags.js" %}></script>
-	<script src={% static "website/js/subtree.js" %}></script>
+	<script src={% static "website/js/subtree_outline.js" %}></script>
 
 {% endblock %}

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -1383,9 +1383,9 @@ def subtree_data(request):
         owner = None
     else:
         owner = User.objects.get(username=owner)
-    
+    print("REQUEST:", request.GET)
     comment_id = request.GET.get('comment_id', None)
-    
+    print("COMMENT ID:", comment_id)
     article_id = int(request.GET['id'])
     a = Article.objects.get(id=article_id)
 
@@ -1427,6 +1427,8 @@ def subtree_data(request):
             posts = None
 
     if posts:
+        for p in posts:
+            print("TEXT OF POST:", p.text)
         val2 = {}
         
         is_collapsed = determine_is_collapsed(posts[0], a)

--- a/wikum/website/views.py
+++ b/wikum/website/views.py
@@ -1383,9 +1383,7 @@ def subtree_data(request):
         owner = None
     else:
         owner = User.objects.get(username=owner)
-    print("REQUEST:", request.GET)
     comment_id = request.GET.get('comment_id', None)
-    print("COMMENT ID:", comment_id)
     article_id = int(request.GET['id'])
     a = Article.objects.get(id=article_id)
 
@@ -1427,8 +1425,6 @@ def subtree_data(request):
             posts = None
 
     if posts:
-        for p in posts:
-            print("TEXT OF POST:", p.text)
         val2 = {}
         
         is_collapsed = determine_is_collapsed(posts[0], a)

--- a/wikum/wikum/routing.py
+++ b/wikum/wikum/routing.py
@@ -23,6 +23,7 @@ application = ProtocolTypeRouter({
         URLRouter([
             # URLRouter just takes standard Django path() or url() entries.
             path('ws/article/<article_id>/visualization_flags', WikumConsumer),
+            path('ws/article/<article_id>/subtree', WikumConsumer),
         ]),
     ),
 


### PR DESCRIPTION
- Outline no longer truncates; gets full words with variable length (the deeper the comment, the shorter)
- Red outline selection for circles and lines are now black
- Subtree view now works
- Fixed bug for viewing previous summaries
- Fixed bug for partial summary nodes that should be normal summary nodes
- Clicking on title twice doesn't collapse conversation